### PR TITLE
Fix error when no files are hidden

### DIFF
--- a/lib/packager.py
+++ b/lib/packager.py
@@ -215,7 +215,7 @@ class Packager:
         self.outputFormat = outputFormat
         self.backdoorFile = None
         self.password = None
-
+        self.hide = ""
         self.fileName = os.path.basename(infile)
         tmpdir = None
         output = False


### PR DESCRIPTION
When no files are hidden and the output format is `iso`, the tool exits with an error:
```
[ERROR] Could not package input file into ISO! Exception: 'Packager' object has no attribute 'hide'
Traceback (most recent call last):
  File "/home/daniel/tools/PackMyPayload/PackMyPayload.py", line 130, in <module>
    main(sys.argv)
  File "/home/daniel/tools/PackMyPayload/PackMyPayload.py", line 122, in main
    if not packager.package(args.infile, args.outfile, outputFormat):
  File "/home/daniel/tools/PackMyPayload/lib/packager.py", line 255, in package
    output = self.packIntoISO(infile, outfile)
  File "/home/daniel/tools/PackMyPayload/lib/packager.py", line 917, in packIntoISO
    if self.hide != '': 
AttributeError: 'Packager' object has no attribute 'hide'
```

This is the case, because `self.hide` is never set to a default when not used in the cli parameters. 
This PR fixes the error by setting the default `self.hide` to an empty string.