### PR TITLE
Hidding directories in ISO

### DIFF
--- a/lib/packager.py
+++ b/lib/packager.py
@@ -941,15 +941,23 @@ DISKPART> detach vdisk
 
                             iso2.add_directory(joliet_path=f'/{jp}')
                     
-                    # Hide file(s) when backdooring existing iso file
-                    if self.hide != '': 
+                    # Hide file(s) and directory(ies) when backdooring existing iso file
+                    if self.hide != '':
                         if type(self.hide) is list:
-                            for hideFile in self.hide:
-                                self.logger.text(f'\tHiding file: //{hideFile}') 
-                                iso2.set_hidden(joliet_path=f'/{hideFile};1')
+                            for hideItem in self.hide:
+                                if re.match(r'.+\..+', hideItem):
+                                    self.logger.text(f'\tHiding file: //{hideItem}') 
+                                    iso2.set_hidden(joliet_path=f'/{hideItem};1')
+                                else:
+                                    self.logger.text(f'\tHiding dir : //{hideItem}') 
+                                    iso2.set_hidden(joliet_path=f'/{hideItem}')
                         else:
-                            self.logger.text(f'\tHiding file: //{self.hide}') 
-                            iso2.set_hidden(joliet_path=f'/{self.hide};1')
+                            if re.match(r'.+\..+', self.hide):
+                                self.logger.text(f'\tHiding file: //{self.hide}') 
+                                iso2.set_hidden(joliet_path=f'/{self.hide};1')
+                            else:
+                                self.logger.text(f'\tHiding dir : //{self.hide}') 
+                                iso2.set_hidden(joliet_path=f'/{self.hide}')
 
                     iso2.write(outfile)
                     iso2.close()
@@ -1004,15 +1012,23 @@ DISKPART> detach vdisk
                             self.logger.text(f'\tAdding file: /{lf}')
                             iso.add_file(fname, joliet_path=f'/{lf};1')
                     
-                # Hide file(s) when specified 
-                if self.hide != '': 
+                # Hide file(s) and directory(ies) when specified 
+                if self.hide != '':
                     if type(self.hide) is list:
-                        for hideFile in self.hide:
-                            self.logger.text(f'\tHiding file: //{hideFile}') 
-                            iso.set_hidden(joliet_path=f'/{hideFile};1')
+                        for hideItem in self.hide:
+                            if re.match(r'.+\..+', hideItem):
+                                self.logger.text(f'\tHiding file: //{hideItem}') 
+                                iso.set_hidden(joliet_path=f'/{hideItem};1')
+                            else:
+                                self.logger.text(f'\tHiding dir : //{hideItem}') 
+                                iso.set_hidden(joliet_path=f'/{hideItem}')
                     else:
-                        self.logger.text(f'\tHiding file: //{self.hide}') 
-                        iso.set_hidden(joliet_path=f'/{self.hide};1')
+                        if re.match(r'.+\..+', self.hide):
+                            self.logger.text(f'\tHiding file: //{self.hide}') 
+                            iso.set_hidden(joliet_path=f'/{self.hide};1')
+                        else:
+                            self.logger.text(f'\tHiding dir : //{self.hide}') 
+                            iso.set_hidden(joliet_path=f'/{self.hide}')
 
                 iso.write(outfile)
                 iso.close()


### PR DESCRIPTION
### **Problem**
As mentionned in the issues #13, it is not possible to hide directories using the flag `--hide` or `--backdoor`.

### **Solution**
ChoiSG, who added the functionnality to hide files, used the function `set_hidden`. 
After reviewing how was working the function, I discover that it was possible to hide directories as well with the same function. 

First things I did was to add a condition to check, with a regex, if a path contain an extension.
```python
if re.match(r'.+\..+', hideItem):
```
If there is, the code of ChoiSG do his job.
```python
if re.match(r'.+\..+', hideItem):
    self.logger.text(f'\tHiding file: //{hideItem}')  
    iso2.set_hidden(joliet_path=f'/{hideItem};1')
```
And, if there is no extension, I consider it is a directory and use almost the same code as for file, except I get rid of the `;1`. 
```python
else:  
   self.logger.text(f'\tHiding dir : //{hideItem}')  
   iso2.set_hidden(joliet_path=f'/{hideItem}')
```
At the end, the library which contain the function `set_hidden` check if the file or directory exist, it then resolve the possible problem of path which are not file or directory.